### PR TITLE
Fix install failure when /usr/local/bin does not exist

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -51,7 +51,13 @@ print_status "Detected macOS with $ARCH architecture"
 # Set variables
 REPO="tsotimus/quick-forge"
 BINARY_NAME="quickforge-darwin-$ARCH"
-INSTALL_DIR="/usr/local/bin"
+
+# Match Homebrew's install location per architecture
+if [[ "$ARCH" == "arm64" ]]; then
+    INSTALL_DIR="/opt/homebrew/bin"
+else
+    INSTALL_DIR="/usr/local/bin"
+fi
 INSTALL_PATH="$INSTALL_DIR/quickforge"
 
 # Check if quickforge is already installed
@@ -98,8 +104,7 @@ chmod +x quickforge
 
 print_status "Installing QuickForge to $INSTALL_PATH..."
 
-# /usr/local/bin often doesn't exist on fresh Apple Silicon Macs until something
-# creates it (Homebrew installs to /opt/homebrew/bin instead).
+# Install dir may not exist yet on a fresh Mac (QuickForge often runs before Homebrew).
 if [[ ! -d "$INSTALL_DIR" ]]; then
     print_status "Creating $INSTALL_DIR..."
     if [[ ! -w "$(dirname "$INSTALL_DIR")" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -98,16 +98,31 @@ chmod +x quickforge
 
 print_status "Installing QuickForge to $INSTALL_PATH..."
 
+# /usr/local/bin often doesn't exist on fresh Apple Silicon Macs until something
+# creates it (Homebrew installs to /opt/homebrew/bin instead).
+if [[ ! -d "$INSTALL_DIR" ]]; then
+    print_status "Creating $INSTALL_DIR..."
+    if [[ ! -w "$(dirname "$INSTALL_DIR")" ]]; then
+        if ! sudo mkdir -p "$INSTALL_DIR"; then
+            print_error "Failed to create $INSTALL_DIR"
+            exit 1
+        fi
+    else
+        mkdir -p "$INSTALL_DIR"
+    fi
+fi
+
 # Check if we need sudo
 if [[ ! -w "$INSTALL_DIR" ]]; then
     print_status "Administrator privileges required to install to $INSTALL_DIR"
     if ! sudo mv quickforge "$INSTALL_PATH"; then
-        print_error "Failed to install QuickForge"
+        print_error "Failed to install QuickForge to $INSTALL_PATH"
+        print_error "If this persists, try: sudo mkdir -p $INSTALL_DIR"
         exit 1
     fi
 else
     if ! mv quickforge "$INSTALL_PATH"; then
-        print_error "Failed to install QuickForge"
+        print_error "Failed to install QuickForge to $INSTALL_PATH"
         exit 1
     fi
 fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Users on fresh Apple Silicon Macs hit this error during install:

```
mv: rename quickforge to /usr/local/bin/quickforge: No such file or directory
[ERROR] Failed to install QuickForge
```

The download step succeeds, but the move fails because the install directory doesn't exist yet.

## Fix

- Install to **Homebrew's standard paths**:
  - Apple Silicon (arm64): `/opt/homebrew/bin`
  - Intel (amd64): `/usr/local/bin`
- Create the install directory with `mkdir -p` before moving the binary
- Improve error messages if installation still fails

This matches how Homebrew itself is laid out, so `quickforge` should be on PATH for most Mac setups (especially after QuickForge installs Homebrew).

## Workaround (until merged)

```bash
sudo mkdir -p /opt/homebrew/bin
curl -fsSL https://raw.githubusercontent.com/tsotimus/quick-forge/main/install.sh | bash
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1d9b-0d50-74de-a049-2caca8c84c10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1d9b-0d50-74de-a049-2caca8c84c10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

