### PR TITLE
Fix install script: use /opt/quickforge/bin and configure PATH

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -51,7 +51,13 @@ print_status "Detected macOS with $ARCH architecture"
 # Set variables
 REPO="tsotimus/quick-forge"
 BINARY_NAME="quickforge-darwin-$ARCH"
-INSTALL_DIR="/usr/local/bin"
+
+# Match Homebrew's install location per architecture
+if [[ "$ARCH" == "arm64" ]]; then
+    INSTALL_DIR="/opt/homebrew/bin"
+else
+    INSTALL_DIR="/usr/local/bin"
+fi
 INSTALL_PATH="$INSTALL_DIR/quickforge"
 
 # Check if quickforge is already installed
@@ -98,8 +104,7 @@ chmod +x quickforge
 
 print_status "Installing QuickForge to $INSTALL_PATH..."
 
-# /usr/local/bin often doesn't exist on fresh Apple Silicon Macs until something
-# creates it (Homebrew installs to /opt/homebrew/bin instead).
+# Install dir may not exist yet on a fresh Mac (QuickForge often runs before Homebrew).
 if [[ ! -d "$INSTALL_DIR" ]]; then
     print_status "Creating $INSTALL_DIR..."
     if [[ ! -w "$(dirname "$INSTALL_DIR")" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -98,16 +98,31 @@ chmod +x quickforge
 
 print_status "Installing QuickForge to $INSTALL_PATH..."
 
+# /usr/local/bin often doesn't exist on fresh Apple Silicon Macs until something
+# creates it (Homebrew installs to /opt/homebrew/bin instead).
+if [[ ! -d "$INSTALL_DIR" ]]; then
+    print_status "Creating $INSTALL_DIR..."
+    if [[ ! -w "$(dirname "$INSTALL_DIR")" ]]; then
+        if ! sudo mkdir -p "$INSTALL_DIR"; then
+            print_error "Failed to create $INSTALL_DIR"
+            exit 1
+        fi
+    else
+        mkdir -p "$INSTALL_DIR"
+    fi
+fi
+
 # Check if we need sudo
 if [[ ! -w "$INSTALL_DIR" ]]; then
     print_status "Administrator privileges required to install to $INSTALL_DIR"
     if ! sudo mv quickforge "$INSTALL_PATH"; then
-        print_error "Failed to install QuickForge"
+        print_error "Failed to install QuickForge to $INSTALL_PATH"
+        print_error "If this persists, try: sudo mkdir -p $INSTALL_DIR"
         exit 1
     fi
 else
     if ! mv quickforge "$INSTALL_PATH"; then
-        print_error "Failed to install QuickForge"
+        print_error "Failed to install QuickForge to $INSTALL_PATH"
         exit 1
     fi
 fi

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,6 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-# Function to print colored output
 print_status() {
     echo -e "${BLUE}[INFO]${NC} $1"
 }
@@ -40,7 +39,7 @@ ARCH=$(uname -m)
 case $ARCH in
     x86_64) ARCH="amd64" ;;
     arm64) ARCH="arm64" ;;
-    *) 
+    *)
         print_error "Unsupported architecture: $ARCH"
         exit 1
         ;;
@@ -48,27 +47,94 @@ esac
 
 print_status "Detected macOS with $ARCH architecture"
 
-# Set variables
 REPO="tsotimus/quick-forge"
 BINARY_NAME="quickforge-darwin-$ARCH"
-
-# Match Homebrew's install location per architecture
-if [[ "$ARCH" == "arm64" ]]; then
-    INSTALL_DIR="/opt/homebrew/bin"
-else
-    INSTALL_DIR="/usr/local/bin"
-fi
+INSTALL_DIR="/opt/quickforge/bin"
 INSTALL_PATH="$INSTALL_DIR/quickforge"
+PATH_MARKER="# Added by QuickForge"
+PATH_LINE="export PATH=\"$INSTALL_DIR:\$PATH\""
+
+get_shell_profile() {
+    case "${SHELL##*/}" in
+        zsh) echo "$HOME/.zprofile" ;;
+        bash) echo "$HOME/.bash_profile" ;;
+        *) echo "$HOME/.profile" ;;
+    esac
+}
+
+ensure_install_dir() {
+    if [[ -d "$INSTALL_DIR" ]]; then
+        return 0
+    fi
+
+    print_status "Creating $INSTALL_DIR..."
+    if ! sudo mkdir -p "$INSTALL_DIR"; then
+        print_error "Failed to create $INSTALL_DIR"
+        exit 1
+    fi
+
+    if ! sudo chown -R "$(whoami)" /opt/quickforge; then
+        print_error "Failed to set ownership on /opt/quickforge"
+        exit 1
+    fi
+}
+
+install_binary() {
+    local source_path="$1"
+
+    if [[ ! -f "$source_path" ]]; then
+        print_error "Downloaded binary not found at $source_path"
+        exit 1
+    fi
+
+    print_status "Installing QuickForge to $INSTALL_PATH..."
+    ensure_install_dir
+
+    if [[ -w "$INSTALL_DIR" ]]; then
+        if ! mv "$source_path" "$INSTALL_PATH"; then
+            print_error "Failed to install QuickForge to $INSTALL_PATH"
+            exit 1
+        fi
+    else
+        print_status "Administrator privileges required to install to $INSTALL_DIR"
+        if ! sudo mv "$source_path" "$INSTALL_PATH"; then
+            print_error "Failed to install QuickForge to $INSTALL_PATH"
+            exit 1
+        fi
+        sudo chown "$(whoami)" "$INSTALL_PATH"
+    fi
+
+    chmod +x "$INSTALL_PATH"
+}
+
+configure_path() {
+    local profile
+    profile="$(get_shell_profile)"
+
+    if [[ -f "$profile" ]] && grep -qF "$INSTALL_DIR" "$profile" 2>/dev/null; then
+        print_status "PATH already configured in ~/${profile##*/}"
+        return 0
+    fi
+
+    print_status "Adding $INSTALL_DIR to PATH in ~/${profile##*/}..."
+    {
+        echo ""
+        echo "$PATH_MARKER"
+        echo "$PATH_LINE"
+    } >> "$profile"
+}
+
+is_quickforge_installed() {
+    [[ -x "$INSTALL_PATH" ]] || command -v quickforge &> /dev/null
+}
 
 # Check if quickforge is already installed
-if command -v quickforge &> /dev/null; then
-    CURRENT_VERSION=$(quickforge --version 2>/dev/null || echo "unknown")
+if is_quickforge_installed; then
+    CURRENT_VERSION=$("$INSTALL_PATH" --version 2>/dev/null || quickforge --version 2>/dev/null || echo "unknown")
     print_warning "QuickForge is already installed (version: $CURRENT_VERSION)"
-    
-    # Check for environment variable first
+
     if [[ "${QUICKFORGE_UPDATE}" == "yes" || "${QUICKFORGE_UPDATE}" == "y" ]]; then
         print_status "Auto-updating due to QUICKFORGE_UPDATE environment variable"
-    # Check if stdin is available (not piped)
     elif [[ -t 0 ]]; then
         read -p "Do you want to update it? (y/N): " -n 1 -r
         echo
@@ -77,75 +143,47 @@ if command -v quickforge &> /dev/null; then
             exit 0
         fi
     else
-        # When piped (stdin not available), default to update
         print_status "Updating QuickForge (piped installation detected)"
         print_status "To skip this prompt in future, use: QUICKFORGE_UPDATE=yes"
     fi
 fi
 
-# Create temporary directory
 TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TEMP_DIR"' EXIT
 cd "$TEMP_DIR"
 
 print_status "Downloading QuickForge..."
 
-# Get the latest release URL
 DOWNLOAD_URL="https://github.com/$REPO/releases/latest/download/$BINARY_NAME"
 
-# Download the binary
 if ! curl -fsSL "$DOWNLOAD_URL" -o quickforge; then
     print_error "Failed to download QuickForge from $DOWNLOAD_URL"
     print_error "Please check if the release exists and try again"
     exit 1
 fi
 
-# Make it executable
 chmod +x quickforge
+install_binary "$TEMP_DIR/quickforge"
+configure_path
 
-print_status "Installing QuickForge to $INSTALL_PATH..."
+export PATH="$INSTALL_DIR:$PATH"
 
-# Install dir may not exist yet on a fresh Mac (QuickForge often runs before Homebrew).
-if [[ ! -d "$INSTALL_DIR" ]]; then
-    print_status "Creating $INSTALL_DIR..."
-    if [[ ! -w "$(dirname "$INSTALL_DIR")" ]]; then
-        if ! sudo mkdir -p "$INSTALL_DIR"; then
-            print_error "Failed to create $INSTALL_DIR"
-            exit 1
-        fi
-    else
-        mkdir -p "$INSTALL_DIR"
-    fi
-fi
-
-# Check if we need sudo
-if [[ ! -w "$INSTALL_DIR" ]]; then
-    print_status "Administrator privileges required to install to $INSTALL_DIR"
-    if ! sudo mv quickforge "$INSTALL_PATH"; then
-        print_error "Failed to install QuickForge to $INSTALL_PATH"
-        print_error "If this persists, try: sudo mkdir -p $INSTALL_DIR"
-        exit 1
-    fi
-else
-    if ! mv quickforge "$INSTALL_PATH"; then
-        print_error "Failed to install QuickForge to $INSTALL_PATH"
-        exit 1
-    fi
-fi
-
-# Clean up
-cd /
-rm -rf "$TEMP_DIR"
-
-# Verify installation
-if command -v quickforge &> /dev/null; then
-    print_success "QuickForge installed successfully!"
-    echo
-    echo "⚡ Run 'quickforge' to get started"
-    echo "⚡ Run 'quickforge --help' for usage information"
-    echo
-    echo "🔨 QuickForge will help you set up your macOS development environment"
-else
-    print_error "Installation completed but quickforge command not found"
-    print_error "You may need to add $INSTALL_DIR to your PATH"
+if [[ ! -x "$INSTALL_PATH" ]]; then
+    print_error "Installation failed: binary missing at $INSTALL_PATH"
     exit 1
-fi 
+fi
+
+print_success "QuickForge installed successfully!"
+echo
+echo "⚡ Run 'quickforge' to get started"
+echo "⚡ Run 'quickforge --help' for usage information"
+echo
+echo "Installed to: $INSTALL_PATH"
+
+if ! command -v quickforge &> /dev/null; then
+    print_warning "Open a new terminal, or run:"
+    echo "  source $(get_shell_profile)"
+fi
+
+echo
+echo "🔨 QuickForge will help you set up your macOS development environment"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Install appeared to fail with:

```
[ERROR] Installation completed but quickforge command not found
[ERROR] You may need to add /opt/homebrew/bin to your PATH
```

The binary was actually being installed, but:
1. `/opt/homebrew/bin` is not on PATH until Homebrew itself is installed
2. The script never configured the user's shell
3. Verification used `command -v quickforge`, which fails when PATH isn't set

## Fix

- Install to a dedicated prefix: **`/opt/quickforge/bin`**
- Create `/opt/quickforge` with user ownership (so updates don't always need sudo)
- Automatically append PATH to `~/.zprofile` (zsh) or `~/.bash_profile` (bash)
- Verify by checking the binary exists at `$INSTALL_PATH`
- Export PATH in the current install session

## Workaround (current broken install)

If you already ran the old script, the binary may exist but isn't on PATH:

```bash
ls -l /opt/homebrew/bin/quickforge 2>/dev/null || ls -l /opt/quickforge/bin/quickforge 2>/dev/null
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1d9b-0d50-74de-a049-2caca8c84c10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1d9b-0d50-74de-a049-2caca8c84c10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

